### PR TITLE
tbplain fix

### DIFF
--- a/plain/tubguide.tex
+++ b/plain/tubguide.tex
@@ -474,9 +474,7 @@ escape character in that block.  Thus,
 ||
 really calls the italic font in the middle of the listing (one might
 also want to use |\makebgroup| and |\makeegroup| in the options to define
-characters to localize this call; see p.~7).  
-
-Situations
+characters to localize this call; see p.~7).  Situations
 will dictate preferences for what character may be used as an escape
 (we use the \verbinline|\endverbatim, |!|, and |/| in this article).
 There is also a means of changing the setup of every occurrence of

--- a/plain/tubguide.tex
+++ b/plain/tubguide.tex
@@ -28,7 +28,7 @@
 \StretchyNinePointSpacing
 \StretchyEightPointSpacing
 
-% \enablemetacode % seems redundant: `<` is used only inside `\everyverbatim` in this article...
+% \enablemetacode % not indispensable for <metacode> outside |\everyverbatim|
 \everyverbatim{\enablemetacode}
 \def\halfline{\vskip 0.5\baselineskip \ignoreendline}
 
@@ -101,8 +101,8 @@ document structure.  Below these are formatting macros that we recognize
 may be essential for certain applications.  Both sorts of tags are
 described in the following article.
 
-Generally, to ``mark up'' the data <foo>, a tag |\xxx| will precede
-<foo> and |\endxxx| will follow (thus: |\xxx <foo>\endxxx|).  We use
+Generally, to ``mark up'' the data |<foo>|, a tag |\xxx| will precede
+|<foo>| and |\endxxx| will follow (thus: |\xxx <foo>\endxxx|).  We use
 the |{...}| form to delimit arguments of lower-level formatting
 macros.  Optional commands follow tags and are enclosed in
 |[\lastoption][...]|, \`a la \LaTeX.  Several options may be enclosed
@@ -477,6 +477,7 @@ also want to use |\makebgroup| and |\makeegroup| in the options to define
 characters to localize this call; see p.~7).  Situations
 will dictate preferences for what character may be used as an escape
 (we use the \verbinline|\endverbatim, |!|, and |/| in this article).
+
 There is also a means of changing the setup of every occurrence of
 verbatim mode.  The contents of token register |\everyverbatim|
 is scanned after the defaults of verbatim mode
@@ -680,7 +681,7 @@ listed under tags.
    \caption{...}
 \twocolfigure
 ||
-and \verbinline|\endverbatim and \verbinline||\endverbatim input syntax.
+|\enablemetacode|, and \verbinline|\endverbatim and \verbinline||\endverbatim input syntax.
 
 
 \head * Common abbreviations and utilities *

--- a/plain/tubguide.tex
+++ b/plain/tubguide.tex
@@ -28,7 +28,7 @@
 \StretchyNinePointSpacing
 \StretchyEightPointSpacing
 
-\enablemetacode
+% \enablemetacode % seems redundant: `<` is used only inside `\everyverbatim` in this article...
 \everyverbatim{\enablemetacode}
 \def\halfline{\vskip 0.5\baselineskip \ignoreendline}
 

--- a/plain/tubguide.tex
+++ b/plain/tubguide.tex
@@ -474,7 +474,9 @@ escape character in that block.  Thus,
 ||
 really calls the italic font in the middle of the listing (one might
 also want to use |\makebgroup| and |\makeegroup| in the options to define
-characters to localize this call; see p.~7).  Situations
+characters to localize this call; see p.~7).  
+
+Situations
 will dictate preferences for what character may be used as an escape
 (we use the \verbinline|\endverbatim, |!|, and |/| in this article).
 There is also a means of changing the setup of every occurrence of
@@ -670,6 +672,11 @@ listed under tags.
    \outputtofile{...}
 \verbinline
 \verbfile
+\enablemetacode
+\tbsurl
+\tbhurl
+\tbmailto
+\tbhref
 \figure
    \mid
    \bot

--- a/plain/tubguide.tex
+++ b/plain/tubguide.tex
@@ -672,7 +672,6 @@ listed under tags.
    \outputtofile{...}
 \verbinline
 \verbfile
-\enablemetacode
 \tbsurl
 \tbhurl
 \tbmailto


### PR DESCRIPTION
1. Removed need for `\enablemetacode` outside `verbatim` environments, by adding `|` verbatim markers on second column paragraph;
2. disabled global scope of the activation of `\enablemetacode`;
3. Added space in the paragraph describing `\enablemetacode` to simplify its localization while browsing the document;
4. Added names of the macros for URL support missing from the summary in a previous update;
5. Added mention to the `\enablemetacode` macro in this summary.